### PR TITLE
Nested parameters

### DIFF
--- a/lib/rack/request_replication/forwarder.rb
+++ b/lib/rack/request_replication/forwarder.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'redis'
+require 'active_support/core_ext/hash/conversions'
 
 module Rack
   module RequestReplication
@@ -215,9 +216,9 @@ module Rack
       # @param   [Hash{Symbol => Object}] opts ({})
       # @returns [Net:HTTP::Post]
       #
-      def create_post_request( uri, opts = {} )
-        forward_request = Net::HTTP::Post.new uri.request_uri
-        forward_request.set_form_data opts[:params]
+      def create_post_request(uri, opts = {})
+        forward_request = Net::HTTP::Post.new(uri.request_uri)
+        forward_request.body = opts[:params].to_query
         forward_request
       end
 
@@ -231,9 +232,9 @@ module Rack
       # @param   [Hash{Symbol => Object}] opts ({})
       # @returns [Net:HTTP::Put]
       #
-      def create_put_request( uri, opts = {} )
-        forward_request = Net::HTTP::Put.new uri.request_uri
-        forward_request.set_form_data opts[:params]
+      def create_put_request(uri, opts = {})
+        forward_request = Net::HTTP::Put.new(uri.request_uri)
+        forward_request.body = opts[:params].to_query
         forward_request
       end
 
@@ -247,9 +248,9 @@ module Rack
       # @param   [Hash{Symbol => Object}] opts ({})
       # @returns [Net:HTTP::Patch]
       #
-      def create_patch_request( uri, opts = {} )
-        forward_request = Net::HTTP::Patch.new uri.request_uri
-        forward_request.set_form_data opts[:params]
+      def create_patch_request(uri, opts = {})
+        forward_request = Net::HTTP::Patch.new(uri.request_uri)
+        forward_request.body = opts[:params].to_query
         forward_request
       end
 

--- a/rack-request_replication.gemspec
+++ b/rack-request_replication.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rack', '>= 1.0.0'
   spec.add_runtime_dependency 'redis', '>= 1.0.0'
+  spec.add_runtime_dependency 'activesupport', '>= 2.1.0'
 end

--- a/spec/app/test_app.rb
+++ b/spec/app/test_app.rb
@@ -23,15 +23,15 @@ class TestApp < Sinatra::Base
   end
 
   post '/' do
-    'POST OK'
+    request.params.to_s
   end
 
   put '/' do
-    'PUT OK'
+    request.params.to_s
   end
 
   patch '/' do
-    'PATCH OK'
+    request.params.to_s
   end
 
   delete '/' do
@@ -60,17 +60,17 @@ class DestApp < Sinatra::Base
   end
 
   post '/' do
-    $destination_responses << 'POST OK'
+    $destination_responses << request.params.to_s
     'Created!'
   end
 
   put '/' do
-    $destination_responses << 'PUT OK'
+    $destination_responses << request.params.to_s
     'Replaced!'
   end
 
   patch '/' do
-    $destination_responses << 'PATCH OK'
+    $destination_responses << request.params.to_s
     'Updated'
   end
 

--- a/spec/forwarder_spec.rb
+++ b/spec/forwarder_spec.rb
@@ -38,21 +38,29 @@ describe Rack::RequestReplication::Forwarder do
   end
 
   describe 'a POST request' do
-    before { post '/', foo: 'bar' }
+    it 'posts correct parameters along parameters' do
+      post '/', foo: 'bar'
+      expect(destination_response).to eq "{\"foo\"=>\"bar\"}"
+    end
 
-    it { expect(last_response.body).to eq destination_response }
+    it "works with nested parameters" do
+      post '/', foo: { bar: 'buz' }
+      expect(destination_response).to eq "{\"foo\"=>{\"bar\"=>\"buz\"}}"
+    end
   end
 
   describe 'a PUT request' do
-    before { put '/', foo: 'bar' }
-
-    it { expect(last_response.body).to eq destination_response }
+    it 'posts correct parameters along parameters' do
+      put '/', foo: { bar: 'buz' }
+      expect(destination_response).to eq "{\"foo\"=>{\"bar\"=>\"buz\"}}"
+    end
   end
 
   describe 'a PATCH request' do
-    before { patch '/', foo: 'bar' }
-
-    it { expect(last_response.body).to eq destination_response }
+    it 'posts correct parameters along parameters' do
+      patch '/', foo: { bar: 'buz' }
+      expect(destination_response).to eq "{\"foo\"=>{\"bar\"=>\"buz\"}}"
+    end
   end
 
   describe 'a DELETE request' do


### PR DESCRIPTION
Makes sure nested parameters like the following keep working

`GET /?utm_medium[test1]=test&utm_medium[test2]=working`

Before this change it would come in as a big string because `set_form_data` cannot handle nested objects.

Proof that it is working ;) : http://img.springe.st/1._tmux_2015-07-22_16-20-00.png
